### PR TITLE
Add architecture support for ppc64

### DIFF
--- a/libmetrics/linux/metrics.c
+++ b/libmetrics/linux/metrics.c
@@ -633,6 +633,8 @@ machine_type_func ( void )
    snprintf(val.str, MAX_G_STRING_SIZE, "hppa");
 #elif __s390__
    snprintf(val.str, MAX_G_STRING_SIZE, "s390");
+#elif __PPC64__
+   snprintf(val.str, MAX_G_STRING_SIZE, "ppc64");
 #else
    snprintf(val.str, MAX_G_STRING_SIZE, "unknown");
 #endif


### PR DESCRIPTION
The right macro was found with "cpp -dM" and tested manually, I have no
idea why it is uppercase while all other arch macros are lowercase...
Possibly something related to AIX compatibility.